### PR TITLE
Fix SSL verify configuration option ignored for Curl

### DIFF
--- a/src/ConfluenceClient.php
+++ b/src/ConfluenceClient.php
@@ -206,9 +206,10 @@ class ConfluenceClient
 
         $this->authorization($ch);
 
-        //FIXME
-        //curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->getConfiguration()->isCurlOptSslVerifyHost());
-        //curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->getConfiguration()->isCurlOptSslVerifyPeer());
+        if (!$this->getConfiguration()->isSslVerify()) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+        }
 
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER,


### PR DESCRIPTION
When using self-signed certificates for Confluence, Curl returns an SSL error because by default it verifies the SSL Cert chain.

    CURL Error: = SSL certificate problem: unable to get local issuer certificate

There is an option in the configuration (`sslVerify`), but it is ignored by Curl, because never implemented (commented out). This PR implements the possibility of disabling SSL verification for Curl.